### PR TITLE
RECOMMIT Left align enketo-notes-list labels

### DIFF
--- a/www/css/main.diary.css
+++ b/www/css/main.diary.css
@@ -494,14 +494,13 @@ enketo-notes-list, .notes-list {
 }
 
 .notes-list {
-  padding: 0 5px 5px 5px;
+  padding: 0 15px 5px 15px;
   text-align: center;
 }
 
 .notes-list-entry {
   display: grid;
   grid-template-columns: 10fr 9fr 1fr;
-  place-items: center;
   overflow: hidden;
   font-size: 13px;
   height: 40px;
@@ -509,4 +508,8 @@ enketo-notes-list, .notes-list {
 
 .notes-list-entry .icon {
   font-size: 24px;
+}
+
+.notes-list-label {
+  text-align: left;
 }

--- a/www/js/survey/enketo/enketo-notes-list.js
+++ b/www/js/survey/enketo/enketo-notes-list.js
@@ -19,7 +19,7 @@ angular.module('emission.survey.enketo.notes-list',
     };
   })
 
-  .controller("NotesListCtrl", function ($scope, $state, $element, $window, EnketoSurveyLaunch) {
+  .controller("NotesListCtrl", function ($scope, $state, $element, $window, EnketoSurveyLaunch, $ionicPopup) {
     console.log("Notes List Controller called");
 
     const getScrollElement = function() {
@@ -40,6 +40,26 @@ angular.module('emission.survey.enketo.notes-list',
       const begin = moment.parseZone(beginTs*1000).tz(timezone).format("h:mm A");
       const stop = moment.parseZone(stopTs*1000).tz(timezone).format("h:mm A");
       return entry.displayTime = begin + " - " + stop;
+    }
+
+    $scope.confirmDeleteEntry = (entry) => {
+      $scope.currEntry = entry;
+      $ionicPopup.show({title: 'Delete entry',
+      templateUrl: `templates/survey/enketo/delete-entry.html`, 
+      scope: $scope,
+        buttons: [{
+          text: 'Delete',
+          type: 'button-cancel',
+          onTap: function(e) {
+            return $scope.deleteEntry(entry);
+          }
+          },{
+          text: 'Cancel',
+          type: 'button-stable',
+        }]
+      });
+
+      return;
     }
 
     $scope.deleteEntry = (entry) => {

--- a/www/templates/diary/place_list_item.html
+++ b/www/templates/diary/place_list_item.html
@@ -4,7 +4,7 @@
         <!-- Start Time Tag -->
         <!-- <div class="start-time-tag">{{place.display_enter_time}}</div> -->
         <div class="diary-card short" style="padding-top: 10px;">
-            <div style="width: 100%; margin: auto; padding: 5px">
+            <div style="width: 100%;">
                 <div class="row place-title">
                     <!-- Place (Destination of Prev. Trip) -->
                     <i class="icon ion-location"></i>

--- a/www/templates/survey/enketo/delete-entry.html
+++ b/www/templates/survey/enketo/delete-entry.html
@@ -1,0 +1,4 @@
+<div style="color:#6e6e6e;">
+  <p style="font-weight: 700;color:#6e6e6e;margin: 0px;">Are you sure you wish to delete this entry?</p>
+  <p>{{currEntry.data.label}}<br />{{currEntry.displayTime || setDisplayTime(entry)}}</p>
+</div>

--- a/www/templates/survey/enketo/notes_list.html
+++ b/www/templates/survey/enketo/notes_list.html
@@ -2,7 +2,7 @@
     <ion-item class="notes-list" style="background-color: transparent">
         <ul>
             <li class="notes-list-entry" ng-repeat="entry in additionEntries | orderBy: 'data.start_ts'">
-                <b class="two-lines" ng-click="editEntry(entry)">{{entry.data.label}}</b>
+                <b class="two-lines notes-list-label" ng-click="editEntry(entry)">{{entry.data.label}}</b>
                 <i ng-click="editEntry(entry)">{{entry.displayTime || setDisplayTime(entry)}}</i>
                 <i class="icon ion-trash-a" ng-click="deleteEntry(entry)"></i>
             </li>

--- a/www/templates/survey/enketo/notes_list.html
+++ b/www/templates/survey/enketo/notes_list.html
@@ -4,7 +4,7 @@
             <li class="notes-list-entry" ng-repeat="entry in additionEntries | orderBy: 'data.start_ts'">
                 <b class="two-lines notes-list-label" ng-click="editEntry(entry)">{{entry.data.label}}</b>
                 <i ng-click="editEntry(entry)">{{entry.displayTime || setDisplayTime(entry)}}</i>
-                <i class="icon ion-trash-a" ng-click="deleteEntry(entry)"></i>
+                <i class="icon ion-trash-a" ng-click="confirmDeleteEntry(entry)"></i>
             </li>
         </ul>
     </ion-item>


### PR DESCRIPTION
Redoing this commit from a separate branch

main.diary.css
- Increased the left and right padding for .notes-list by 10px
- Removed the place-items: center as it was overriding the left alignment
- Added a new style called notes-list-label which aligns the text to the left

place_list_item.html
- Removed the in-element styling for diary cards because this is now handled with the css

notes_list.html
- The notes-list-label class is not being used by the notes-list label field to left align it